### PR TITLE
fix(webapp): correct Spanish decimal parsing and UTC date handling

### DIFF
--- a/apps/webapp/src/app/(main)/analysis/new/page.tsx
+++ b/apps/webapp/src/app/(main)/analysis/new/page.tsx
@@ -31,6 +31,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { ANALYSIS_TYPE_OPTIONS } from '@/constants/analysis-types'
 import { useAnalysisForm } from '@/hooks/use-analysis-form'
 import { handleDomainError } from '@/lib/error-handler'
+import { todayLocalDateString } from '@/lib/local-date'
 import { useUserStore } from '@/stores/user/user-provider'
 import { api } from '@/trpc/react'
 
@@ -201,7 +202,7 @@ export default function NewAnalysisPage() {
                 id="analyzedAt"
                 type="date"
                 value={formData.analyzedAt}
-                max={new Date().toISOString().split('T')[0]}
+                max={todayLocalDateString()}
                 onChange={(e) => updateFormData('analyzedAt', e.target.value)}
                 className={errors.analyzedAt ? 'border-destructive' : ''}
               />

--- a/apps/webapp/src/app/(main)/export/analysis/dates/page.tsx
+++ b/apps/webapp/src/app/(main)/export/analysis/dates/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ANALYSIS_TYPE_OPTIONS } from '@/constants/analysis-types'
+import { toLocalDateString } from '@/lib/local-date'
 
 export default function DateRangeSelectorPage() {
   const router = useRouter()
@@ -26,8 +27,8 @@ export default function DateRangeSelectorPage() {
     const oneYearAgo = new Date()
     oneYearAgo.setFullYear(today.getFullYear() - 1)
 
-    setEndDate(today.toISOString().split('T')[0] || '')
-    setStartDate(oneYearAgo.toISOString().split('T')[0] || '')
+    setEndDate(toLocalDateString(today))
+    setStartDate(toLocalDateString(oneYearAgo))
   }, [])
 
   // Parsear tipos seleccionados desde URL

--- a/apps/webapp/src/app/(main)/export/incidents/page.tsx
+++ b/apps/webapp/src/app/(main)/export/incidents/page.tsx
@@ -15,6 +15,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import { toLocalDateString } from '@/lib/local-date'
 
 export default function IncidentsExportPage() {
   const router = useRouter()
@@ -28,8 +29,8 @@ export default function IncidentsExportPage() {
     const oneYearAgo = new Date()
     oneYearAgo.setFullYear(today.getFullYear() - 1)
 
-    setEndDate(today.toISOString().split('T')[0] || '')
-    setStartDate(oneYearAgo.toISOString().split('T')[0] || '')
+    setEndDate(toLocalDateString(today))
+    setStartDate(toLocalDateString(oneYearAgo))
   }, [])
 
   const handleExport = () => {

--- a/apps/webapp/src/app/(main)/export/incidents/results/page.tsx
+++ b/apps/webapp/src/app/(main)/export/incidents/results/page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { toLocalDateString } from '@/lib/local-date'
 import { useIncidentsPDFGenerator } from '../../_hooks/use-incidents-pdf-generator'
 
 export default function IncidentsExportResultsPage() {
@@ -50,8 +51,8 @@ export default function IncidentsExportResultsPage() {
       const oneYearAgo = new Date()
       oneYearAgo.setFullYear(today.getFullYear() - 1)
 
-      const defaultEndDate = today.toISOString().split('T')[0] || ''
-      const defaultStartDate = oneYearAgo.toISOString().split('T')[0] || ''
+      const defaultEndDate = toLocalDateString(today)
+      const defaultStartDate = toLocalDateString(oneYearAgo)
 
       setEndDate(defaultEndDate)
       setStartDate(defaultStartDate)

--- a/apps/webapp/src/app/(main)/export/readings/page.tsx
+++ b/apps/webapp/src/app/(main)/export/readings/page.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import { toLocalDateString } from '@/lib/local-date'
 import { useUserStore } from '@/stores/user/user-provider'
 import { api } from '@/trpc/react'
 
@@ -68,8 +69,8 @@ export default function ReadingsExportPage() {
     const oneYearAgo = new Date()
     oneYearAgo.setFullYear(today.getFullYear() - 1)
 
-    setEndDate(today.toISOString().split('T')[0] || '')
-    setStartDate(oneYearAgo.toISOString().split('T')[0] || '')
+    setEndDate(toLocalDateString(today))
+    setStartDate(toLocalDateString(oneYearAgo))
   }, [])
 
   const handleExport = () => {

--- a/apps/webapp/src/app/(main)/export/readings/results/page.tsx
+++ b/apps/webapp/src/app/(main)/export/readings/results/page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { toLocalDateString } from '@/lib/local-date'
 import { useReadingsPDFGenerator } from '../../_hooks/use-readings-pdf-generator'
 
 export default function ReadingsExportResultsPage() {
@@ -54,8 +55,8 @@ export default function ReadingsExportResultsPage() {
       const oneYearAgo = new Date()
       oneYearAgo.setFullYear(today.getFullYear() - 1)
 
-      const defaultEndDate = today.toISOString().split('T')[0] || ''
-      const defaultStartDate = oneYearAgo.toISOString().split('T')[0] || ''
+      const defaultEndDate = toLocalDateString(today)
+      const defaultStartDate = toLocalDateString(oneYearAgo)
 
       setEndDate(defaultEndDate)
       setStartDate(defaultStartDate)

--- a/apps/webapp/src/app/(main)/fees/_components/fee-payment-form.tsx
+++ b/apps/webapp/src/app/(main)/fees/_components/fee-payment-form.tsx
@@ -30,6 +30,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
+import { toLocalDateString } from '@/lib/local-date'
 import { api } from '@/trpc/react'
 import { frequencyLabels, kindLabels, paymentMethodLabels, periodOptions } from '../_lib/fee-labels'
 
@@ -151,7 +152,7 @@ export default function FeePaymentForm({
   const paidAtInputValue = useMemo(() => {
     const date = paidAtValue instanceof Date ? paidAtValue : new Date(paidAtValue)
     if (Number.isNaN(date.getTime())) return ''
-    return date.toISOString().slice(0, 10)
+    return toLocalDateString(date)
   }, [paidAtValue])
 
   return (

--- a/apps/webapp/src/app/(main)/management/meter-replacement/_components/meter-replacement-form.tsx
+++ b/apps/webapp/src/app/(main)/management/meter-replacement/_components/meter-replacement-form.tsx
@@ -37,6 +37,7 @@ import {
 import { ConnectionNumberLabel } from '@/components/water-point/connection-number-label'
 import { useImageUpload } from '@/hooks/use-image-upload'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { todayLocalDateString } from '@/lib/local-date'
 import { api } from '@/trpc/react'
 import { ACCEPTED_FILE_TYPES } from '@/types/image'
 
@@ -117,7 +118,7 @@ export default function MeterReplacementForm({
     defaultValues: {
       newWaterMeterName: '',
       measurementUnit: 'M3',
-      replacementDate: new Date().toISOString().split('T')[0],
+      replacementDate: todayLocalDateString(),
       finalReading: ''
     }
   })
@@ -131,7 +132,7 @@ export default function MeterReplacementForm({
       form.reset({
         newWaterMeterName: meter.waterPoint.name,
         measurementUnit: meter.measurementUnit as 'L' | 'M3',
-        replacementDate: new Date().toISOString().split('T')[0],
+        replacementDate: todayLocalDateString(),
         finalReading: ''
       })
     }

--- a/apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx
+++ b/apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx
@@ -71,8 +71,10 @@ export function EditReadingModal({ isOpen, onClose, reading, onSuccess }: EditRe
   const form = useForm<EditReadingFormData>({
     resolver: zodResolver(editReadingSchema),
     defaultValues: {
-      // Ungrouped on purpose: a grouped value like "12.345,00" would be
-      // mangled to 12,345 by the first keystroke through normalizeDecimalInput.
+      // Ungrouped and to three decimals on purpose: the column is
+      // Decimal(10, 3), and this value is resubmitted verbatim even when the
+      // user only edits a note, so any rounding here silently rewrites the
+      // stored reading.
       reading: formatForInput(Number.parseFloat(reading.reading)),
       notes: reading.notes || ''
     }

--- a/apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx
+++ b/apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx
@@ -53,7 +53,7 @@ interface EditReadingModalProps {
 }
 
 export function EditReadingModal({ isOpen, onClose, reading, onSuccess }: EditReadingModalProps) {
-  const { parseSpanishNumber, formatToSpanish } = useSpanishNumberParser()
+  const { parseSpanishNumber, formatForInput, normalizeDecimalInput } = useSpanishNumberParser()
   const isMobile = useIsMobile()
 
   // Image state management
@@ -71,7 +71,9 @@ export function EditReadingModal({ isOpen, onClose, reading, onSuccess }: EditRe
   const form = useForm<EditReadingFormData>({
     resolver: zodResolver(editReadingSchema),
     defaultValues: {
-      reading: formatToSpanish(parseFloat(reading.reading)),
+      // Ungrouped on purpose: a grouped value like "12.345,00" would be
+      // mangled to 12,345 by the first keystroke through normalizeDecimalInput.
+      reading: formatForInput(Number.parseFloat(reading.reading)),
       notes: reading.notes || ''
     }
   })
@@ -189,7 +191,9 @@ export function EditReadingModal({ isOpen, onClose, reading, onSuccess }: EditRe
                         <FormControl>
                           <Input
                             placeholder="Ingresa la nueva lectura"
+                            inputMode="decimal"
                             {...field}
+                            onChange={(e) => field.onChange(normalizeDecimalInput(e.target.value))}
                             disabled={updateReadingMutation.isPending}
                           />
                         </FormControl>
@@ -282,7 +286,9 @@ export function EditReadingModal({ isOpen, onClose, reading, onSuccess }: EditRe
                       <FormControl>
                         <Input
                           placeholder="Ingresa la nueva lectura"
+                          inputMode="decimal"
                           {...field}
+                          onChange={(e) => field.onChange(normalizeDecimalInput(e.target.value))}
                           disabled={updateReadingMutation.isPending}
                         />
                       </FormControl>

--- a/apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx
+++ b/apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx
@@ -19,6 +19,7 @@ import { useImageUpload } from '@/hooks/use-image-upload'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useSpanishNumberParser } from '@/hooks/use-spanish-number-parser'
 import { handleDomainError } from '@/lib/error-handler'
+import { todayLocalDateString } from '@/lib/local-date'
 import { type ReadingValidationError, validateReading } from '@/lib/reading-validation'
 import { api } from '@/trpc/react'
 import { ACCEPTED_FILE_TYPES } from '@/types/image'
@@ -33,7 +34,7 @@ interface AddReadingModalProps {
 }
 
 function getCurrentDateString(): string {
-  return new Date().toISOString().split('T')[0] ?? ''
+  return todayLocalDateString()
 }
 
 function getCurrentTimeString(): string {
@@ -68,7 +69,7 @@ export function AddReadingModal({
   const [validationError, setValidationError] = useState<ReadingValidationError | null>(null)
 
   const utils = api.useUtils()
-  const { parseSpanishNumber } = useSpanishNumberParser()
+  const { parseSpanishNumber, normalizeDecimalInput } = useSpanishNumberParser()
   const { imagePreview, imageError, handleImageSelect, handleRemoveImage, getImageData } =
     useImageUpload('image')
   const isMobile = useIsMobile()
@@ -165,15 +166,10 @@ export function AddReadingModal({
   }
 
   const handleReadingChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-
-    // Allow only: digits, comma (one only), dots, and empty string
-    const validPattern = /^[0-9]*[.,]?[0-9]*$/
-
-    if (validPattern.test(value) || value === '') {
-      setReadingForm((prev) => ({ ...prev, reading: value }))
-      setValidationError(null)
-    }
+    // Normalising rather than gating: a typed "." becomes the decimal comma,
+    // so "1234.5" can no longer be stored as 12345.
+    setReadingForm((prev) => ({ ...prev, reading: normalizeDecimalInput(e.target.value) }))
+    setValidationError(null)
   }
 
   const handleClose = () => {

--- a/apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx
+++ b/apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx
@@ -166,8 +166,9 @@ export function AddReadingModal({
   }
 
   const handleReadingChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // Normalising rather than gating: a typed "." becomes the decimal comma,
-    // so "1234.5" can no longer be stored as 12345.
+    // Filter rather than gate: keep what the user typed (dots included) and
+    // let parseSpanishNumber decide whether a dot groups thousands or marks
+    // decimals, once the number is complete.
     setReadingForm((prev) => ({ ...prev, reading: normalizeDecimalInput(e.target.value) }))
     setValidationError(null)
   }

--- a/apps/webapp/src/hooks/use-analysis-form.ts
+++ b/apps/webapp/src/hooks/use-analysis-form.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { AnalysisType } from '@/constants/analysis-types'
+import { todayLocalDateString } from '@/lib/local-date'
 
 export interface AnalysisFormData {
   analysisType: AnalysisType | ''
@@ -21,7 +22,7 @@ export function useAnalysisForm(initialAnalyst: string = '') {
   const [formData, setFormData] = useState<AnalysisFormData>({
     analysisType: '',
     analyst: initialAnalyst,
-    analyzedAt: new Date().toISOString().split('T')[0],
+    analyzedAt: todayLocalDateString(),
     communityZoneId: '',
     waterDepositId: '',
     ph: '',
@@ -90,7 +91,7 @@ export function useAnalysisForm(initialAnalyst: string = '') {
     setFormData({
       analysisType: '',
       analyst: initialAnalyst,
-      analyzedAt: new Date().toISOString().split('T')[0],
+      analyzedAt: todayLocalDateString(),
       communityZoneId: '',
       waterDepositId: '',
       ph: '',

--- a/apps/webapp/src/hooks/use-spanish-number-parser.ts
+++ b/apps/webapp/src/hooks/use-spanish-number-parser.ts
@@ -1,32 +1,15 @@
+import {
+  formatForInput,
+  formatToSpanish,
+  normalizeDecimalInput,
+  parseSpanishNumber
+} from '@/lib/spanish-number'
+
+/**
+ * Thin wrapper over `@/lib/spanish-number` so existing components keep their
+ * call sites. Prefer importing from the lib directly in new code — the
+ * functions are pure and need no hook.
+ */
 export function useSpanishNumberParser() {
-  /**
-   * Converts Spanish number format to standard number format
-   * Examples: "1.234,56" → 1234.56, "1234,56" → 1234.56
-   */
-  const parseSpanishNumber = (value: string): number => {
-    if (!value || value.trim() === '') return 0
-
-    // Remove spaces
-    const cleaned = value.trim()
-    // Remove dots (thousands separators)
-    const withoutThousands = cleaned.replace(/\./g, '')
-    // Replace comma with dot (decimal separator)
-    const normalized = withoutThousands.replace(',', '.')
-
-    const parsed = parseFloat(normalized)
-    return Number.isNaN(parsed) ? 0 : parsed
-  }
-
-  /**
-   * Converts number to Spanish format (for display purposes)
-   * Example: 1234.56 → "1.234,56"
-   */
-  const formatToSpanish = (value: number): string => {
-    return value.toLocaleString('es-ES', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2
-    })
-  }
-
-  return { parseSpanishNumber, formatToSpanish }
+  return { parseSpanishNumber, formatToSpanish, formatForInput, normalizeDecimalInput }
 }

--- a/apps/webapp/src/lib/local-date.test.ts
+++ b/apps/webapp/src/lib/local-date.test.ts
@@ -1,0 +1,47 @@
+// Pin the timezone so this suite is deterministic wherever it runs, including
+// a CI box on UTC. Verified: this assignment takes effect in bun and overrides
+// an inherited TZ, so the UTC-vs-local contrast below is always exercised.
+process.env.TZ = 'Europe/Madrid'
+
+import { describe, expect, it } from 'bun:test'
+import { todayLocalDateString, toLocalDateString } from './local-date'
+
+describe('toLocalDateString', () => {
+  it('returns the local calendar day, not the UTC one', () => {
+    // 00:30 local on 30 July in Madrid (UTC+2) is still 29 July in UTC.
+    // `toISOString().split('T')[0]` returned the 29th — that was the bug.
+    const justAfterLocalMidnight = new Date(2026, 6, 30, 0, 30)
+
+    expect(justAfterLocalMidnight.toISOString().split('T')[0]).toBe('2026-07-29')
+    expect(toLocalDateString(justAfterLocalMidnight)).toBe('2026-07-30')
+  })
+
+  it('handles a winter date, when Madrid is UTC+1', () => {
+    const justAfterLocalMidnight = new Date(2026, 0, 15, 0, 30)
+
+    expect(justAfterLocalMidnight.toISOString().split('T')[0]).toBe('2026-01-14')
+    expect(toLocalDateString(justAfterLocalMidnight)).toBe('2026-01-15')
+  })
+
+  it('agrees with UTC during the middle of the day', () => {
+    expect(toLocalDateString(new Date(2026, 6, 30, 12, 0))).toBe('2026-07-30')
+  })
+
+  it('zero-pads month and day', () => {
+    expect(toLocalDateString(new Date(2026, 0, 5, 9, 0))).toBe('2026-01-05')
+  })
+
+  it('handles the last instant of a local day', () => {
+    expect(toLocalDateString(new Date(2026, 6, 30, 23, 59, 59))).toBe('2026-07-30')
+  })
+})
+
+describe('todayLocalDateString', () => {
+  it('matches toLocalDateString for now', () => {
+    expect(todayLocalDateString()).toBe(toLocalDateString(new Date()))
+  })
+
+  it('is a valid YYYY-MM-DD string', () => {
+    expect(todayLocalDateString()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})

--- a/apps/webapp/src/lib/local-date.ts
+++ b/apps/webapp/src/lib/local-date.ts
@@ -1,0 +1,18 @@
+import { format } from 'date-fns'
+
+/**
+ * Formats a Date as YYYY-MM-DD in the runtime's local timezone.
+ *
+ * Replaces `toISOString().split('T')[0]`, which returns the UTC day: in Spain
+ * (UTC+1/+2) that is still yesterday between local midnight and 01:00/02:00,
+ * so a reading taken then was dated a day early and today could not even be
+ * selected where the value was used as an input's `max`.
+ */
+export function toLocalDateString(date: Date): string {
+  return format(date, 'yyyy-MM-dd')
+}
+
+/** Today as YYYY-MM-DD in local time. */
+export function todayLocalDateString(): string {
+  return toLocalDateString(new Date())
+}

--- a/apps/webapp/src/lib/spanish-number.test.ts
+++ b/apps/webapp/src/lib/spanish-number.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  formatForInput,
+  formatToSpanish,
+  normalizeDecimalInput,
+  parseSpanishNumber
+} from './spanish-number'
+
+describe('parseSpanishNumber', () => {
+  it('parses plain integers', () => {
+    expect(parseSpanishNumber('1234')).toBe(1234)
+  })
+
+  it('treats the comma as the decimal separator', () => {
+    expect(parseSpanishNumber('1234,56')).toBe(1234.56)
+    expect(parseSpanishNumber('0,5')).toBe(0.5)
+    expect(parseSpanishNumber(',5')).toBe(0.5)
+  })
+
+  it('treats dots as thousands separators', () => {
+    expect(parseSpanishNumber('1.234,56')).toBe(1234.56)
+    expect(parseSpanishNumber('1.234.567,89')).toBe(1234567.89)
+    expect(parseSpanishNumber('1.234')).toBe(1234)
+  })
+
+  it('returns 0 for empty or non-numeric input', () => {
+    expect(parseSpanishNumber('')).toBe(0)
+    expect(parseSpanishNumber('   ')).toBe(0)
+    expect(parseSpanishNumber('abc')).toBe(0)
+  })
+})
+
+describe('normalizeDecimalInput', () => {
+  it('converts a typed dot into the decimal comma', () => {
+    // This is the 10x-corruption bug: "1234.5" used to parse as 12345.
+    expect(normalizeDecimalInput('1234.5')).toBe('1234,5')
+  })
+
+  it('leaves an already-normal value untouched', () => {
+    expect(normalizeDecimalInput('1234,5')).toBe('1234,5')
+    expect(normalizeDecimalInput('1234,00')).toBe('1234,00')
+  })
+
+  it('keeps only the first separator', () => {
+    expect(normalizeDecimalInput('1,2,3')).toBe('1,23')
+    expect(normalizeDecimalInput('12.34.5')).toBe('12,345')
+  })
+
+  it('strips non-numeric characters', () => {
+    expect(normalizeDecimalInput('abc12')).toBe('12')
+    expect(normalizeDecimalInput('')).toBe('')
+  })
+
+  it('keeps a leading separator', () => {
+    expect(normalizeDecimalInput(',5')).toBe(',5')
+    expect(normalizeDecimalInput('.5')).toBe(',5')
+  })
+
+  it('is idempotent', () => {
+    for (const raw of [
+      '1234.5',
+      '1234,5',
+      '1,2,3',
+      '12.34.5',
+      'abc12',
+      ',5',
+      '.5',
+      '',
+      '1234,00'
+    ]) {
+      const once = normalizeDecimalInput(raw)
+      expect(normalizeDecimalInput(once)).toBe(once)
+    }
+  })
+
+  it('only ever emits digits and at most one comma', () => {
+    for (const raw of ['1.234,56', 'a1b2.3c,4', '...,,,', '9']) {
+      const out = normalizeDecimalInput(raw)
+      expect(out).toMatch(/^[0-9]*,?[0-9]*$/)
+    }
+  })
+})
+
+describe('formatForInput', () => {
+  it('never groups thousands, however large', () => {
+    expect(formatForInput(0)).toBe('0,00')
+    expect(formatForInput(1234.56)).toBe('1234,56')
+    expect(formatForInput(12345)).toBe('12345,00')
+    expect(formatForInput(1234567.89)).toBe('1234567,89')
+  })
+
+  it('produces a value normalizeDecimalInput leaves untouched', () => {
+    for (const v of [0, 5, 1234, 12345, 1234.56, 1234567.89]) {
+      const seeded = formatForInput(v)
+      expect(normalizeDecimalInput(seeded)).toBe(seeded)
+    }
+  })
+})
+
+describe('formatToSpanish', () => {
+  it('groups thousands for display', () => {
+    expect(formatToSpanish(12345)).toBe('12.345,00')
+    expect(formatToSpanish(1234567.89)).toBe('1.234.567,89')
+  })
+
+  it('omits grouping below five integer digits, as es-ES does', () => {
+    // Intl's es-ES minimumGroupingDigits is 2, so four-digit integers are
+    // not grouped. Pinned here because the formatForInput split below only
+    // matters for values that DO get grouped.
+    expect(formatToSpanish(1234)).toBe('1234,00')
+    expect(formatToSpanish(999)).toBe('999,00')
+  })
+})
+
+describe('why formatForInput exists', () => {
+  it('normalising a grouped display value would corrupt it by 1000x', () => {
+    // A realistic meter reading. Seeding an input with the *display* format
+    // and then normalising one keystroke would silently divide it by 1000.
+    const reading = 12345
+    const grouped = formatToSpanish(reading)
+    expect(grouped).toBe('12.345,00')
+    expect(parseSpanishNumber(normalizeDecimalInput(grouped))).toBe(12.345)
+
+    // Seeding with the input format is stable under the same keystroke.
+    const seeded = formatForInput(reading)
+    expect(parseSpanishNumber(normalizeDecimalInput(seeded))).toBe(reading)
+  })
+})
+
+describe('round trips', () => {
+  it('survives the input format', () => {
+    for (const v of [0, 0.5, 5, 1234, 1234.56, 1234567.89]) {
+      expect(parseSpanishNumber(formatForInput(v))).toBe(v)
+    }
+  })
+
+  it('survives the display format', () => {
+    for (const v of [0, 0.5, 5, 1234, 1234.56, 1234567.89]) {
+      expect(parseSpanishNumber(formatToSpanish(v))).toBe(v)
+    }
+  })
+})

--- a/apps/webapp/src/lib/spanish-number.test.ts
+++ b/apps/webapp/src/lib/spanish-number.test.ts
@@ -17,10 +17,9 @@ describe('parseSpanishNumber', () => {
     expect(parseSpanishNumber(',5')).toBe(0.5)
   })
 
-  it('treats dots as thousands separators', () => {
+  it('treats dots as thousands separators when a comma is present', () => {
     expect(parseSpanishNumber('1.234,56')).toBe(1234.56)
     expect(parseSpanishNumber('1.234.567,89')).toBe(1234567.89)
-    expect(parseSpanishNumber('1.234')).toBe(1234)
   })
 
   it('returns 0 for empty or non-numeric input', () => {
@@ -28,55 +27,70 @@ describe('parseSpanishNumber', () => {
     expect(parseSpanishNumber('   ')).toBe(0)
     expect(parseSpanishNumber('abc')).toBe(0)
   })
+
+  // The disambiguation that matters. A dot followed by exactly three digits
+  // groups thousands; anything else is a decimal point. These four rows are
+  // the shapes a field worker actually types.
+  describe('a lone dot, disambiguated by what follows it', () => {
+    it('groups thousands when exactly three digits follow', () => {
+      expect(parseSpanishNumber('12.345')).toBe(12345)
+      expect(parseSpanishNumber('1.234')).toBe(1234)
+      expect(parseSpanishNumber('1.234.567')).toBe(1234567)
+      expect(parseSpanishNumber('12.345.678')).toBe(12345678)
+    })
+
+    it('is a decimal point otherwise', () => {
+      expect(parseSpanishNumber('1234.5')).toBe(1234.5)
+      expect(parseSpanishNumber('12.34')).toBe(12.34)
+      expect(parseSpanishNumber('1.2345')).toBe(1.2345)
+      expect(parseSpanishNumber('0.5')).toBe(0.5)
+    })
+
+    it('treats a leading dot as a decimal point, never as grouping', () => {
+      expect(parseSpanishNumber('.5')).toBe(0.5)
+      expect(parseSpanishNumber('.500')).toBe(0.5)
+    })
+
+    it('keeps earlier dots as grouping when the last one is decimal', () => {
+      expect(parseSpanishNumber('1.234.56')).toBe(1234.56)
+    })
+  })
 })
 
 describe('normalizeDecimalInput', () => {
-  it('converts a typed dot into the decimal comma', () => {
-    // This is the 10x-corruption bug: "1234.5" used to parse as 12345.
-    expect(normalizeDecimalInput('1234.5')).toBe('1234,5')
+  it('keeps digits, dots and one comma', () => {
+    expect(normalizeDecimalInput('1234.5')).toBe('1234.5')
+    expect(normalizeDecimalInput('1.234,56')).toBe('1.234,56')
+    expect(normalizeDecimalInput('12.345')).toBe('12.345')
   })
 
-  it('leaves an already-normal value untouched', () => {
-    expect(normalizeDecimalInput('1234,5')).toBe('1234,5')
-    expect(normalizeDecimalInput('1234,00')).toBe('1234,00')
+  it('does not rewrite the separator', () => {
+    // Interpreting the separator is parseSpanishNumber's job, once the number
+    // is complete. Rewriting here would commit too early.
+    expect(normalizeDecimalInput('12.3')).toBe('12.3')
   })
 
-  it('keeps only the first separator', () => {
+  it('drops a second comma', () => {
     expect(normalizeDecimalInput('1,2,3')).toBe('1,23')
-    expect(normalizeDecimalInput('12.34.5')).toBe('12,345')
   })
 
   it('strips non-numeric characters', () => {
     expect(normalizeDecimalInput('abc12')).toBe('12')
+    expect(normalizeDecimalInput('-5')).toBe('5')
+    expect(normalizeDecimalInput('1 234')).toBe('1234')
     expect(normalizeDecimalInput('')).toBe('')
   })
 
-  it('keeps a leading separator', () => {
-    expect(normalizeDecimalInput(',5')).toBe(',5')
-    expect(normalizeDecimalInput('.5')).toBe(',5')
-  })
-
   it('is idempotent', () => {
-    for (const raw of [
-      '1234.5',
-      '1234,5',
-      '1,2,3',
-      '12.34.5',
-      'abc12',
-      ',5',
-      '.5',
-      '',
-      '1234,00'
-    ]) {
+    for (const raw of ['1234.5', '1.234,56', '1,2,3', 'abc12', ',5', '.5', '', '1234,00', '-5']) {
       const once = normalizeDecimalInput(raw)
       expect(normalizeDecimalInput(once)).toBe(once)
     }
   })
 
-  it('only ever emits digits and at most one comma', () => {
-    for (const raw of ['1.234,56', 'a1b2.3c,4', '...,,,', '9']) {
-      const out = normalizeDecimalInput(raw)
-      expect(out).toMatch(/^[0-9]*,?[0-9]*$/)
+  it('only ever emits digits, dots and at most one comma', () => {
+    for (const raw of ['1.234,56', 'a1b2.3c,4', '...,,,', '9', '€12,50']) {
+      expect(normalizeDecimalInput(raw)).toMatch(/^[0-9.]*,?[0-9.]*$/)
     }
   })
 })
@@ -89,10 +103,15 @@ describe('formatForInput', () => {
     expect(formatForInput(1234567.89)).toBe('1234567,89')
   })
 
-  it('produces a value normalizeDecimalInput leaves untouched', () => {
-    for (const v of [0, 5, 1234, 12345, 1234.56, 1234567.89]) {
-      const seeded = formatForInput(v)
-      expect(normalizeDecimalInput(seeded)).toBe(seeded)
+  it('keeps the third decimal the schema stores', () => {
+    // reading is Decimal(10, 3). At two decimals, opening the edit modal to
+    // change only a note would silently round the stored reading.
+    expect(formatForInput(1234.567)).toBe('1234,567')
+  })
+
+  it('round-trips through the parser', () => {
+    for (const v of [0, 0.5, 5, 1234, 12345, 1234.56, 1234.567, 1234567.89]) {
+      expect(parseSpanishNumber(formatForInput(v))).toBe(v)
     }
   })
 })
@@ -104,39 +123,30 @@ describe('formatToSpanish', () => {
   })
 
   it('omits grouping below five integer digits, as es-ES does', () => {
-    // Intl's es-ES minimumGroupingDigits is 2, so four-digit integers are
-    // not grouped. Pinned here because the formatForInput split below only
-    // matters for values that DO get grouped.
     expect(formatToSpanish(1234)).toBe('1234,00')
-    expect(formatToSpanish(999)).toBe('999,00')
-  })
-})
-
-describe('why formatForInput exists', () => {
-  it('normalising a grouped display value would corrupt it by 1000x', () => {
-    // A realistic meter reading. Seeding an input with the *display* format
-    // and then normalising one keystroke would silently divide it by 1000.
-    const reading = 12345
-    const grouped = formatToSpanish(reading)
-    expect(grouped).toBe('12.345,00')
-    expect(parseSpanishNumber(normalizeDecimalInput(grouped))).toBe(12.345)
-
-    // Seeding with the input format is stable under the same keystroke.
-    const seeded = formatForInput(reading)
-    expect(parseSpanishNumber(normalizeDecimalInput(seeded))).toBe(reading)
-  })
-})
-
-describe('round trips', () => {
-  it('survives the input format', () => {
-    for (const v of [0, 0.5, 5, 1234, 1234.56, 1234567.89]) {
-      expect(parseSpanishNumber(formatForInput(v))).toBe(v)
-    }
   })
 
-  it('survives the display format', () => {
-    for (const v of [0, 0.5, 5, 1234, 1234.56, 1234567.89]) {
+  it('round-trips through the parser', () => {
+    for (const v of [0, 0.5, 5, 1234, 12345, 1234.56, 1234.567, 1234567.89]) {
       expect(parseSpanishNumber(formatToSpanish(v))).toBe(v)
     }
+  })
+})
+
+describe('the corruption paths this module exists to close', () => {
+  it('no longer multiplies a keypad decimal by ten', () => {
+    // Was: every dot stripped as grouping, so "1234.5" became 12345.
+    expect(parseSpanishNumber('1234.5')).toBe(1234.5)
+  })
+
+  it('still reads a Spanish grouped integer correctly', () => {
+    // A live-normalising input would have turned this into 12,345.
+    expect(parseSpanishNumber('12.345')).toBe(12345)
+  })
+
+  it('survives an edit-modal round trip for a three-decimal reading', () => {
+    const stored = 12345.678
+    const seeded = formatForInput(stored)
+    expect(parseSpanishNumber(normalizeDecimalInput(seeded))).toBe(stored)
   })
 })

--- a/apps/webapp/src/lib/spanish-number.ts
+++ b/apps/webapp/src/lib/spanish-number.ts
@@ -1,60 +1,99 @@
 /**
- * Spanish number handling.
+ * Spanish number handling for meter readings.
  *
  * In Spanish notation the comma is the decimal separator and the dot groups
- * thousands. A raw text input cannot distinguish a user typing "1234.5"
- * (meaning 1234,5) from the thousands form "1.234" — so the ambiguity is
- * removed at the keystroke by normalizeDecimalInput rather than guessed at
- * here. Every input guarded by it holds only digits and at most one comma.
+ * thousands — but people typing on a phone keypad routinely use the dot as a
+ * decimal point too. Both intentions are real and both reach these inputs:
+ *
+ *   "12.345"  a Spanish grouped integer     -> 12345
+ *   "1234.5"  a keypad decimal              -> 1234.5
+ *
+ * Neither can be honoured by a fixed rule, so parseSpanishNumber disambiguates
+ * the way every locale-aware parser does: a dot followed by exactly three
+ * digits groups thousands, anything else is a decimal point. That is a
+ * heuristic, but it is right for every shape a meter reading actually takes,
+ * and it is applied at parse time rather than as the user types — normalising
+ * mid-keystroke would commit to an interpretation before the number is
+ * finished (after "12.3" you cannot yet know whether "12.345" is coming).
  */
+
+/** True when the dot at `index` groups thousands rather than marking decimals. */
+function isThousandsSeparator(value: string, index: number): boolean {
+  const digitsAfter = value.length - index - 1
+  return digitsAfter === 3 && index > 0
+}
 
 /** Converts a Spanish-formatted number string to a JS number. */
 export function parseSpanishNumber(value: string): number {
   if (!value || value.trim() === '') return 0
 
-  const withoutThousands = value.trim().replace(/\./g, '')
-  const normalized = withoutThousands.replace(',', '.')
-  const parsed = Number.parseFloat(normalized)
+  const trimmed = value.trim()
 
+  // A comma is unambiguous: it is the decimal separator, dots group thousands.
+  if (trimmed.includes(',')) {
+    return toNumber(trimmed.replace(/\./g, '').replace(',', '.'))
+  }
+
+  const lastDot = trimmed.lastIndexOf('.')
+  if (lastDot === -1) return toNumber(trimmed)
+
+  if (isThousandsSeparator(trimmed, lastDot)) {
+    return toNumber(trimmed.replace(/\./g, ''))
+  }
+
+  // The last dot is a decimal point; any earlier dot still groups thousands.
+  const head = trimmed.slice(0, lastDot).replace(/\./g, '')
+  return toNumber(`${head}.${trimmed.slice(lastDot + 1)}`)
+}
+
+function toNumber(value: string): number {
+  const parsed = Number.parseFloat(value)
   return Number.isNaN(parsed) ? 0 : parsed
 }
 
-/** Formats a number for display, grouped: 1234 -> "1.234,00" */
+/**
+ * Formats a number for display, grouped: 12345 -> "12.345,00".
+ * Three decimals because the reading column is Decimal(10, 3).
+ */
 export function formatToSpanish(value: number): string {
   return value.toLocaleString('es-ES', {
     minimumFractionDigits: 2,
-    maximumFractionDigits: 2
+    maximumFractionDigits: 3
   })
 }
 
 /**
- * Formats a number to seed a text input, ungrouped: 1234 -> "1234,00".
- * Never contains a dot, so normalizeDecimalInput is idempotent over it.
+ * Formats a number to seed a text input, ungrouped: 12345 -> "12345,00".
+ *
+ * Ungrouped so the seeded value cannot itself be re-read as a grouped number,
+ * and to three decimals because the reading column is Decimal(10, 3): at two,
+ * opening the edit modal to change only a note would silently round the stored
+ * reading.
  */
 export function formatForInput(value: number): string {
   return value.toLocaleString('es-ES', {
     minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    maximumFractionDigits: 3,
     useGrouping: false
   })
 }
 
 /**
- * Normalises a reading input as the user types. The first separator typed —
- * dot or comma — becomes the decimal comma; every later separator and any
- * non-digit is dropped. Output is always /^[0-9]*,?[0-9]*$/ and applying this
- * twice changes nothing.
+ * Filters a reading input as the user types: keeps digits, dots and at most
+ * one comma, and drops everything else. It deliberately does NOT rewrite the
+ * separator — interpreting it is parseSpanishNumber's job, once the number is
+ * complete.
  */
 export function normalizeDecimalInput(value: string): string {
-  let hasSeparator = false
+  let hasComma = false
   let result = ''
 
   for (const char of value) {
-    if (char >= '0' && char <= '9') {
+    if ((char >= '0' && char <= '9') || char === '.') {
       result += char
-    } else if ((char === '.' || char === ',') && !hasSeparator) {
-      hasSeparator = true
-      result += ','
+    } else if (char === ',' && !hasComma) {
+      hasComma = true
+      result += char
     }
   }
 

--- a/apps/webapp/src/lib/spanish-number.ts
+++ b/apps/webapp/src/lib/spanish-number.ts
@@ -1,0 +1,62 @@
+/**
+ * Spanish number handling.
+ *
+ * In Spanish notation the comma is the decimal separator and the dot groups
+ * thousands. A raw text input cannot distinguish a user typing "1234.5"
+ * (meaning 1234,5) from the thousands form "1.234" — so the ambiguity is
+ * removed at the keystroke by normalizeDecimalInput rather than guessed at
+ * here. Every input guarded by it holds only digits and at most one comma.
+ */
+
+/** Converts a Spanish-formatted number string to a JS number. */
+export function parseSpanishNumber(value: string): number {
+  if (!value || value.trim() === '') return 0
+
+  const withoutThousands = value.trim().replace(/\./g, '')
+  const normalized = withoutThousands.replace(',', '.')
+  const parsed = Number.parseFloat(normalized)
+
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+/** Formats a number for display, grouped: 1234 -> "1.234,00" */
+export function formatToSpanish(value: number): string {
+  return value.toLocaleString('es-ES', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })
+}
+
+/**
+ * Formats a number to seed a text input, ungrouped: 1234 -> "1234,00".
+ * Never contains a dot, so normalizeDecimalInput is idempotent over it.
+ */
+export function formatForInput(value: number): string {
+  return value.toLocaleString('es-ES', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    useGrouping: false
+  })
+}
+
+/**
+ * Normalises a reading input as the user types. The first separator typed —
+ * dot or comma — becomes the decimal comma; every later separator and any
+ * non-digit is dropped. Output is always /^[0-9]*,?[0-9]*$/ and applying this
+ * twice changes nothing.
+ */
+export function normalizeDecimalInput(value: string): string {
+  let hasSeparator = false
+  let result = ''
+
+  for (const char of value) {
+    if (char >= '0' && char <= '9') {
+      result += char
+    } else if ((char === '.' || char === ',') && !hasSeparator) {
+      hasSeparator = true
+      result += ','
+    }
+  }
+
+  return result
+}

--- a/docs/superpowers/plans/2026-07-30-data-correctness.md
+++ b/docs/superpowers/plans/2026-07-30-data-correctness.md
@@ -1,0 +1,680 @@
+# Data-Correctness Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate two pre-existing data-corruption bugs — a Spanish number parser that turns `1234.5` into `12345`, and `toISOString()` producing the wrong calendar day in local time across 17 sites.
+
+**Architecture:** Two new pure modules under `apps/webapp/src/lib/` (`spanish-number.ts`, `local-date.ts`), each with colocated `bun:test` files. The number ambiguity is removed at the input rather than guessed at in the parser: a new `normalizeDecimalInput` converts a typed `.` to `,` so an input's value only ever contains digits and at most one comma. `use-spanish-number-parser.ts` becomes a thin wrapper over the pure module so its two consumers keep their call sites.
+
+**Tech Stack:** TypeScript, `date-fns` (already the repo's dominant date library), `bun:test`, Biome 2.2.2.
+
+**Design spec:** `docs/superpowers/specs/2026-07-30-data-correctness-design.md`
+
+## Global Constraints
+
+- **UI language is Spanish** for user-visible strings. Code identifiers and comments stay English.
+- **Test runner is `bun:test`.** Import from `'bun:test'`. No jsdom, no React Testing Library — **do not add them**, no component tests. `bun test` already runs in CI.
+- **No new dependencies.** `date-fns` is already in `apps/webapp/package.json`.
+- **Biome 2.2.2 on the exact files you changed, never a directory** — a directory run reformats unrelated files in this repo. After running it, `git diff --stat` and confirm only your files appear.
+- **`git add` explicit file paths only.** Never `git add -A`.
+- **Infrastructure is out of bounds:** `next.config.js`, any `package.json`, `bun.lock`, `src/server/db.ts`, `packages/database/**`.
+- **Do not touch `apps/webapp/src/app/admin/**`.**
+- **Leave the 4 PDF-filename `toISOString()` sites alone** — an off-by-one in a filename is harmless and they are explicitly out of scope.
+- **Out of scope entirely:** the failing production build (an admin file imports an undeclared `@radix-ui/react-dropdown-menu`), `Date.now()` in React keys, hardcoded colour classes, duplicated mobile/desktop branches, backfilling already-stored readings.
+
+---
+
+## File Structure
+
+**New files:**
+
+| File | Responsibility |
+|---|---|
+| `apps/webapp/src/lib/spanish-number.ts` | Pure Spanish number parsing/formatting/input normalisation. |
+| `apps/webapp/src/lib/spanish-number.test.ts` | `bun:test` contract + idempotency + round-trip tests. |
+| `apps/webapp/src/lib/local-date.ts` | Local-timezone `YYYY-MM-DD` formatting via date-fns. |
+| `apps/webapp/src/lib/local-date.test.ts` | `bun:test` incl. a real timezone regression test. |
+
+**Modified files:**
+
+| File | Change |
+|---|---|
+| `apps/webapp/src/hooks/use-spanish-number-parser.ts` | Becomes a thin wrapper re-exporting the pure functions. |
+| `apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx` | `handleReadingChange` uses `normalizeDecimalInput`; date default uses `todayLocalDateString`. |
+| `apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx` | Both reading inputs normalise; form seeded with `formatForInput`. |
+| 9 further files | Replace `toISOString()` date values — full table in Task 4. |
+
+---
+
+## Task 1: The pure Spanish-number module
+
+**Files:**
+- Create: `apps/webapp/src/lib/spanish-number.ts`
+- Test: `apps/webapp/src/lib/spanish-number.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```ts
+  export function parseSpanishNumber(value: string): number
+  export function formatToSpanish(value: number): string      // grouped, display: 1234 -> "1.234,00"
+  export function formatForInput(value: number): string       // ungrouped, input: 1234 -> "1234,00"
+  export function normalizeDecimalInput(value: string): string
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/webapp/src/lib/spanish-number.test.ts`:
+
+```ts
+import { describe, expect, it } from 'bun:test'
+import {
+  formatForInput,
+  formatToSpanish,
+  normalizeDecimalInput,
+  parseSpanishNumber
+} from './spanish-number'
+
+describe('parseSpanishNumber', () => {
+  it('parses plain integers', () => {
+    expect(parseSpanishNumber('1234')).toBe(1234)
+  })
+
+  it('treats the comma as the decimal separator', () => {
+    expect(parseSpanishNumber('1234,56')).toBe(1234.56)
+    expect(parseSpanishNumber('0,5')).toBe(0.5)
+    expect(parseSpanishNumber(',5')).toBe(0.5)
+  })
+
+  it('treats dots as thousands separators', () => {
+    expect(parseSpanishNumber('1.234,56')).toBe(1234.56)
+    expect(parseSpanishNumber('1.234.567,89')).toBe(1234567.89)
+    expect(parseSpanishNumber('1.234')).toBe(1234)
+  })
+
+  it('returns 0 for empty or non-numeric input', () => {
+    expect(parseSpanishNumber('')).toBe(0)
+    expect(parseSpanishNumber('   ')).toBe(0)
+    expect(parseSpanishNumber('abc')).toBe(0)
+  })
+})
+
+describe('normalizeDecimalInput', () => {
+  it('converts a typed dot into the decimal comma', () => {
+    // This is the 10x-corruption bug: "1234.5" used to parse as 12345.
+    expect(normalizeDecimalInput('1234.5')).toBe('1234,5')
+  })
+
+  it('leaves an already-normal value untouched', () => {
+    expect(normalizeDecimalInput('1234,5')).toBe('1234,5')
+    expect(normalizeDecimalInput('1234,00')).toBe('1234,00')
+  })
+
+  it('keeps only the first separator', () => {
+    expect(normalizeDecimalInput('1,2,3')).toBe('1,23')
+    expect(normalizeDecimalInput('12.34.5')).toBe('12,345')
+  })
+
+  it('strips non-numeric characters', () => {
+    expect(normalizeDecimalInput('abc12')).toBe('12')
+    expect(normalizeDecimalInput('')).toBe('')
+  })
+
+  it('keeps a leading separator', () => {
+    expect(normalizeDecimalInput(',5')).toBe(',5')
+    expect(normalizeDecimalInput('.5')).toBe(',5')
+  })
+
+  it('is idempotent', () => {
+    for (const raw of ['1234.5', '1234,5', '1,2,3', '12.34.5', 'abc12', ',5', '.5', '', '1234,00']) {
+      const once = normalizeDecimalInput(raw)
+      expect(normalizeDecimalInput(once)).toBe(once)
+    }
+  })
+
+  it('only ever emits digits and at most one comma', () => {
+    for (const raw of ['1.234,56', 'a1b2.3c,4', '...,,,', '9']) {
+      const out = normalizeDecimalInput(raw)
+      expect(out).toMatch(/^[0-9]*,?[0-9]*$/)
+    }
+  })
+})
+
+describe('formatForInput', () => {
+  it('formats without thousands grouping', () => {
+    expect(formatForInput(1234)).toBe('1234,00')
+    expect(formatForInput(1234.56)).toBe('1234,56')
+    expect(formatForInput(0)).toBe('0,00')
+  })
+
+  it('produces a value normalizeDecimalInput leaves untouched', () => {
+    for (const v of [0, 5, 1234, 1234.56, 1234567.89]) {
+      const seeded = formatForInput(v)
+      expect(normalizeDecimalInput(seeded)).toBe(seeded)
+    }
+  })
+})
+
+describe('formatToSpanish', () => {
+  it('groups thousands for display', () => {
+    expect(formatToSpanish(1234)).toBe('1.234,00')
+    expect(formatToSpanish(1234.56)).toBe('1.234,56')
+  })
+})
+
+describe('round trips', () => {
+  it('survives the input format', () => {
+    for (const v of [0, 0.5, 5, 1234, 1234.56, 1234567.89]) {
+      expect(parseSpanishNumber(formatForInput(v))).toBe(v)
+    }
+  })
+
+  it('survives the display format', () => {
+    for (const v of [0, 0.5, 5, 1234, 1234.56, 1234567.89]) {
+      expect(parseSpanishNumber(formatToSpanish(v))).toBe(v)
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun test apps/webapp/src/lib/spanish-number.test.ts
+```
+
+Expected: FAIL — `Cannot find module './spanish-number'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/webapp/src/lib/spanish-number.ts`:
+
+```ts
+/**
+ * Spanish number handling.
+ *
+ * In Spanish notation the comma is the decimal separator and the dot groups
+ * thousands. A raw text input cannot distinguish a user typing "1234.5"
+ * (meaning 1234,5) from the thousands form "1.234" — so the ambiguity is
+ * removed at the keystroke by normalizeDecimalInput rather than guessed at
+ * here. Every input guarded by it holds only digits and at most one comma.
+ */
+
+/** Converts a Spanish-formatted number string to a JS number. */
+export function parseSpanishNumber(value: string): number {
+  if (!value || value.trim() === '') return 0
+
+  const withoutThousands = value.trim().replace(/\./g, '')
+  const normalized = withoutThousands.replace(',', '.')
+  const parsed = Number.parseFloat(normalized)
+
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+/** Formats a number for display, grouped: 1234 -> "1.234,00" */
+export function formatToSpanish(value: number): string {
+  return value.toLocaleString('es-ES', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })
+}
+
+/**
+ * Formats a number to seed a text input, ungrouped: 1234 -> "1234,00".
+ * Never contains a dot, so normalizeDecimalInput is idempotent over it.
+ */
+export function formatForInput(value: number): string {
+  return value.toLocaleString('es-ES', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    useGrouping: false
+  })
+}
+
+/**
+ * Normalises a reading input as the user types. The first separator typed —
+ * dot or comma — becomes the decimal comma; every later separator and any
+ * non-digit is dropped. Output is always /^[0-9]*,?[0-9]*$/ and applying this
+ * twice changes nothing.
+ */
+export function normalizeDecimalInput(value: string): string {
+  let hasSeparator = false
+  let result = ''
+
+  for (const char of value) {
+    if (char >= '0' && char <= '9') {
+      result += char
+    } else if ((char === '.' || char === ',') && !hasSeparator) {
+      hasSeparator = true
+      result += ','
+    }
+  }
+
+  return result
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun test apps/webapp/src/lib/spanish-number.test.ts
+```
+
+Expected: PASS, 0 fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun x biome check --write apps/webapp/src/lib/spanish-number.ts apps/webapp/src/lib/spanish-number.test.ts
+git add apps/webapp/src/lib/spanish-number.ts apps/webapp/src/lib/spanish-number.test.ts
+git commit -m "feat(webapp): add pure Spanish number module with input normalisation"
+```
+
+---
+
+## Task 2: The local-date module
+
+**Files:**
+- Create: `apps/webapp/src/lib/local-date.ts`
+- Test: `apps/webapp/src/lib/local-date.test.ts`
+
+**Interfaces:**
+- Consumes: `format` from `date-fns` (already a dependency).
+- Produces:
+  ```ts
+  export function toLocalDateString(date: Date): string
+  export function todayLocalDateString(): string
+  ```
+
+**Verified fact:** setting `process.env.TZ = 'Europe/Madrid'` at the top of a bun test file does change `Date` behaviour (`new Date(2026, 6, 30, 0, 30).getTimezoneOffset()` → `-120`, and its `toISOString()` yields `2026-07-29`). That makes a real regression test possible rather than a merely contractual one.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/webapp/src/lib/local-date.test.ts`. The `process.env.TZ` assignment must come before the import so the module is evaluated under the fixed zone:
+
+```ts
+process.env.TZ = 'Europe/Madrid'
+
+import { describe, expect, it } from 'bun:test'
+import { toLocalDateString, todayLocalDateString } from './local-date'
+
+describe('toLocalDateString', () => {
+  it('returns the local calendar day, not the UTC one', () => {
+    // 00:30 local on 30 July in Madrid (UTC+2) is still 29 July in UTC.
+    // The old `toISOString().split('T')[0]` returned the 29th — that was the bug.
+    const justAfterLocalMidnight = new Date(2026, 6, 30, 0, 30)
+
+    expect(justAfterLocalMidnight.toISOString().split('T')[0]).toBe('2026-07-29')
+    expect(toLocalDateString(justAfterLocalMidnight)).toBe('2026-07-30')
+  })
+
+  it('agrees with UTC during the middle of the day', () => {
+    expect(toLocalDateString(new Date(2026, 6, 30, 12, 0))).toBe('2026-07-30')
+  })
+
+  it('handles a winter date, when Madrid is UTC+1', () => {
+    const justAfterLocalMidnight = new Date(2026, 0, 15, 0, 30)
+
+    expect(justAfterLocalMidnight.toISOString().split('T')[0]).toBe('2026-01-14')
+    expect(toLocalDateString(justAfterLocalMidnight)).toBe('2026-01-15')
+  })
+
+  it('zero-pads month and day', () => {
+    expect(toLocalDateString(new Date(2026, 0, 5, 9, 0))).toBe('2026-01-05')
+  })
+})
+
+describe('todayLocalDateString', () => {
+  it('matches toLocalDateString for now', () => {
+    expect(todayLocalDateString()).toBe(toLocalDateString(new Date()))
+  })
+
+  it('is a valid YYYY-MM-DD string', () => {
+    expect(todayLocalDateString()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun test apps/webapp/src/lib/local-date.test.ts
+```
+
+Expected: FAIL — `Cannot find module './local-date'`.
+
+If instead the two `toISOString()` assertions fail, `process.env.TZ` is not taking effect in your environment. Do not delete those assertions to make it green — report it, and fall back to running the suite with `TZ=Europe/Madrid bun test`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/webapp/src/lib/local-date.ts`:
+
+```ts
+import { format } from 'date-fns'
+
+/**
+ * Formats a Date as YYYY-MM-DD in the runtime's local timezone.
+ *
+ * Replaces `toISOString().split('T')[0]`, which returns the UTC day: in Spain
+ * (UTC+1/+2) that is still yesterday between local midnight and 01:00/02:00,
+ * so a reading taken then was stored a day early.
+ */
+export function toLocalDateString(date: Date): string {
+  return format(date, 'yyyy-MM-dd')
+}
+
+/** Today as YYYY-MM-DD in local time. */
+export function todayLocalDateString(): string {
+  return toLocalDateString(new Date())
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun test apps/webapp/src/lib/local-date.test.ts
+```
+
+Expected: PASS, 0 fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun x biome check --write apps/webapp/src/lib/local-date.ts apps/webapp/src/lib/local-date.test.ts
+git add apps/webapp/src/lib/local-date.ts apps/webapp/src/lib/local-date.test.ts
+git commit -m "feat(webapp): add local-timezone date formatting module"
+```
+
+---
+
+## Task 3: Rewire the reading inputs
+
+**Files:**
+- Modify: `apps/webapp/src/hooks/use-spanish-number-parser.ts`
+- Modify: `apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx`
+- Modify: `apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx`
+
+**Interfaces:**
+- Consumes: everything from Task 1.
+- Produces: nothing new. The hook keeps returning `{ parseSpanishNumber, formatToSpanish }` and gains `formatForInput` and `normalizeDecimalInput`, so existing destructuring keeps working.
+
+- [ ] **Step 1: Make the hook a thin wrapper**
+
+Replace the whole body of `apps/webapp/src/hooks/use-spanish-number-parser.ts` with:
+
+```ts
+import {
+  formatForInput,
+  formatToSpanish,
+  normalizeDecimalInput,
+  parseSpanishNumber
+} from '@/lib/spanish-number'
+
+/**
+ * Thin wrapper over `@/lib/spanish-number` so existing components keep their
+ * call sites. Prefer importing from the lib directly in new code — the
+ * functions are pure and need no hook.
+ */
+export function useSpanishNumberParser() {
+  return { parseSpanishNumber, formatToSpanish, formatForInput, normalizeDecimalInput }
+}
+```
+
+- [ ] **Step 2: Normalise the add-reading input**
+
+In `add-reading-modal.tsx`, pull `normalizeDecimalInput` out of the hook where `parseSpanishNumber` is already destructured (currently line ~71):
+
+```ts
+  const { parseSpanishNumber, normalizeDecimalInput } = useSpanishNumberParser()
+```
+
+`handleReadingChange` currently reads:
+
+```ts
+  const handleReadingChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+
+    // Allow only: digits, comma (one only), dots, and empty string
+    const validPattern = /^[0-9]*[.,]?[0-9]*$/
+
+    if (validPattern.test(value) || value === '') {
+      setReadingForm((prev) => ({ ...prev, reading: value }))
+      setValidationError(null)
+    }
+  }
+```
+
+Replace it with:
+
+```ts
+  const handleReadingChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // Normalising rather than gating: a typed "." becomes the decimal comma,
+    // so "1234.5" can no longer be stored as 12345.
+    setReadingForm((prev) => ({ ...prev, reading: normalizeDecimalInput(e.target.value) }))
+    setValidationError(null)
+  }
+```
+
+- [ ] **Step 3: Normalise both edit-reading inputs and seed the form ungrouped**
+
+In `edit-reading-modal.tsx`:
+
+Change the destructure (currently line ~56) from `formatToSpanish` to the two functions now needed:
+
+```ts
+  const { parseSpanishNumber, formatForInput, normalizeDecimalInput } = useSpanishNumberParser()
+```
+
+Change the form seed (currently line ~74) from:
+
+```ts
+      reading: formatToSpanish(parseFloat(reading.reading)),
+```
+
+to:
+
+```ts
+      reading: formatForInput(Number.parseFloat(reading.reading)),
+```
+
+The modal renders its whole form twice, so there are **two** reading `<Input>` elements (around lines 190 and 283), each spreading react-hook-form's `field` with no filtering. For **each** of them, override `onChange` after the `{...field}` spread so the spread does not clobber it:
+
+```tsx
+                          <Input
+                            placeholder="Ingresa la nueva lectura"
+                            {...field}
+                            onChange={(e) => field.onChange(normalizeDecimalInput(e.target.value))}
+                            disabled={updateReadingMutation.isPending}
+```
+
+Keep every other prop exactly as it is, and keep `inputMode`/`type` unchanged if present. Verify by grep that **both** inputs got the override.
+
+- [ ] **Step 4: Verify**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+grep -c "normalizeDecimalInput" "apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx"
+```
+Expected: `3` (one destructure + two `onChange` overrides).
+
+```bash
+grep -n "formatToSpanish" "apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx"
+```
+Expected: no output — the display-grouped formatter is no longer used here.
+
+```bash
+bun test
+bun x tsc --noEmit -p apps/webapp/tsconfig.json 2>&1 | grep -E "spanish-number|local-date|add-reading-modal|edit-reading-modal|use-spanish"
+```
+Expected: suite passes; no tsc output for those files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun x biome check --write apps/webapp/src/hooks/use-spanish-number-parser.ts \
+  "apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx" \
+  "apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx"
+git add apps/webapp/src/hooks/use-spanish-number-parser.ts \
+  "apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx" \
+  "apps/webapp/src/app/(main)/water-meter/[id]/_components/edit-reading-modal.tsx"
+git commit -m "fix(webapp): stop a typed decimal point multiplying readings by ten"
+```
+
+---
+
+## Task 4: Replace the 17 UTC date sites
+
+**Files — 17 date-value sites across 10 files.** Replace `new Date().toISOString().split('T')[0]` with `todayLocalDateString()`, and `<someDate>.toISOString().split('T')[0]` / `.slice(0, 10)` with `toLocalDateString(<someDate>)`. Import from `@/lib/local-date`.
+
+| File | Lines |
+|---|---|
+| `apps/webapp/src/hooks/use-analysis-form.ts` | 24, 93 |
+| `apps/webapp/src/app/(main)/fees/_components/fee-payment-form.tsx` | 154 (`.slice(0, 10)`) |
+| `apps/webapp/src/app/(main)/management/meter-replacement/_components/meter-replacement-form.tsx` | 120, 134 |
+| `apps/webapp/src/app/(main)/analysis/new/page.tsx` | 204 (`max=`) |
+| `apps/webapp/src/app/(main)/water-meter/new/_components/add-reading-modal.tsx` | 36 (inside `getCurrentDateString`) |
+| `apps/webapp/src/app/(main)/export/readings/page.tsx` | 71, 72 |
+| `apps/webapp/src/app/(main)/export/readings/results/page.tsx` | 57, 58 |
+| `apps/webapp/src/app/(main)/export/incidents/page.tsx` | 31, 32 |
+| `apps/webapp/src/app/(main)/export/incidents/results/page.tsx` | 53, 54 |
+| `apps/webapp/src/app/(main)/export/analysis/dates/page.tsx` | 29, 30 |
+
+**Do NOT touch these 4 filename sites** — an off-by-one in a PDF filename is harmless:
+`export/_hooks/use-readings-pdf-generator.ts` (61, 62), `use-analysis-pdf-generator.ts` (66), `use-incidents-pdf-generator.ts` (61).
+
+**Interfaces:**
+- Consumes: `toLocalDateString`, `todayLocalDateString` from Task 2.
+
+- [ ] **Step 1: Simplify `getCurrentDateString` in the reading modal**
+
+`add-reading-modal.tsx` line ~34 defines:
+
+```ts
+function getCurrentDateString(): string {
+  return new Date().toISOString().split('T')[0] ?? ''
+}
+```
+
+Replace the body with `return todayLocalDateString()` and add the import. Keep the function — it is called in three places (the form default and the two `max` attributes), so keeping it avoids touching those call sites.
+
+- [ ] **Step 2: Replace the remaining 16 sites**
+
+Work file by file. In each, add the import and swap the expression. The two shapes are:
+
+```ts
+// before
+analyzedAt: new Date().toISOString().split('T')[0],
+// after
+analyzedAt: todayLocalDateString(),
+```
+
+```ts
+// before
+setEndDate(today.toISOString().split('T')[0] || '')
+// after
+setEndDate(toLocalDateString(today))
+```
+
+Note the `|| ''` and `?? ''` fallbacks exist only because `split('T')[0]` is typed `string | undefined`. `toLocalDateString` returns `string`, so drop the fallback rather than leaving dead code.
+
+`fee-payment-form.tsx:154` uses the other shape:
+
+```ts
+// before
+return date.toISOString().slice(0, 10)
+// after
+return toLocalDateString(date)
+```
+
+- [ ] **Step 3: Verify no date-value site remains**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+grep -rn "toISOString()" apps/webapp/src --include=*.tsx --include=*.ts
+```
+
+Expected: exactly **4** matches, all of them the PDF-filename sites listed above. Any other match is a site you missed.
+
+```bash
+bun test
+bun x tsc --noEmit -p apps/webapp/tsconfig.json 2>&1 | grep -vE "^packages/" > /tmp/after.txt
+git stash push -u -m "data-correctness-tsc-baseline-probe"
+bun x tsc --noEmit -p apps/webapp/tsconfig.json 2>&1 | grep -vE "^packages/" > /tmp/before.txt
+git stash list --format='%H %gs' | head -1
+```
+Then restore with `git stash apply <sha>` (not pop) and drop the entry by re-finding it by tag. Compare `/tmp/before.txt` and `/tmp/after.txt` — the counts must match, proving no new type errors.
+
+If stashing feels risky, an equivalent check is to run tsc and confirm none of the reported files are ones you edited.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun x biome check --write <the 10 files you edited>
+git add <the 10 files you edited>
+git commit -m "fix(webapp): use local calendar day instead of the UTC day
+
+toISOString() returns the UTC date, which in Spain (UTC+1/+2) is still
+yesterday between local midnight and 01:00/02:00. Default form dates,
+date-input max attributes and export ranges were all a day early for
+anyone using the app then."
+```
+
+---
+
+## Task 5: Final verification and pull request
+
+**Files:** none modified.
+
+- [ ] **Step 1: Full suite**
+
+```bash
+cd /home/agustin/src/puntodeagua/.claude/worktrees/data-correctness
+bun test
+```
+Expected: all pass. The baseline before this work was 311 pass / 0 fail; the new lib tests add to that.
+
+- [ ] **Step 2: Lint**
+
+```bash
+bun x biome check --max-diagnostics=20000 --diagnostic-level=error .
+```
+Expected: 0 errors (the repo was clean at the branch point).
+
+- [ ] **Step 3: Confirm scope**
+
+```bash
+git diff --name-only worktree-frontend-fixes..HEAD
+```
+Expected: only the 4 new lib files, the hook, the 10 edited files, and the two docs. No `package.json`, no `bun.lock`, no `packages/database/**`, nothing under `app/admin/`.
+
+- [ ] **Step 4: Open the PR, stacked on PR #7**
+
+```bash
+git push -u origin data-correctness
+gh pr create --draft --base worktree-frontend-fixes --head data-correctness \
+  --title "fix(webapp): correct Spanish decimal parsing and UTC date handling" \
+  --body-file <a file you write covering: the two bugs with concrete before/after values, the
+              input-normalisation decision and why it beats a parser heuristic, the three
+              behaviour changes users will notice, and the explicit note that historical
+              data is NOT migrated>
+```
+
+Base is `worktree-frontend-fixes`, not `main`, so the PR shows only this work. Retarget to `main` once #7 merges.
+
+---
+
+## Self-Review
+
+**Spec coverage:** the design's two bugs map to Tasks 1+3 (number) and Tasks 2+4 (dates); the `formatForInput` decision is implemented in Task 1 Step 3 and consumed in Task 3 Step 3; the testing section's idempotency and round-trip requirements are in Task 1 Step 1; the timezone regression test is Task 2 Step 1.
+
+**Type consistency:** `parseSpanishNumber`, `formatToSpanish`, `formatForInput`, `normalizeDecimalInput` are declared in Task 1 and consumed with identical names in Task 3. `toLocalDateString`/`todayLocalDateString` are declared in Task 2 and consumed in Task 4.
+
+**Known behaviour changes**, all called out in the design and to be repeated in the PR body: default dates shift by up to a day for late-night users; typing `.` now renders `,`; the edit modal gains input filtering it never had.

--- a/docs/superpowers/specs/2026-07-30-data-correctness-design.md
+++ b/docs/superpowers/specs/2026-07-30-data-correctness-design.md
@@ -54,7 +54,34 @@ Three approaches were considered:
 - **B — normalise at the input (chosen):** typing `.` inserts `,`. The parser then treats comma as the only decimal separator and dots strictly as thousands, with no special cases.
 - **C — one separator always means decimal:** rejected, silently breaks `1.234` = 1234.
 
-**B is chosen.** It resolves the ambiguity where the intent exists — at the keystroke — rather than inferring it later. On a mobile numeric keypad the decimal key is commonly `.`, and converting it to `,` matches the format the app already displays (`formatToSpanish` always emits a comma, e.g. `1234` → `"1234,00"`). The user sees immediately what will be recorded.
+**B was chosen initially, then reversed during implementation. A is what shipped.**
+
+Option B normalised the separator as the user typed. Review of the implementation showed this
+trades one silent corruption for a worse one — it commits to an interpretation before the number
+is finished, so a Spanish user typing the grouped form loses a factor of 1000:
+
+| typed | before this work | under option B | correct |
+|---|---|---|---|
+| `12.345` | 12345 ✅ | **12,345** ❌ | 12345 |
+| `1234.5` | **12345** ❌ | 1234,5 ✅ | 1234,5 |
+| `1.234` | 1234 ✅ | **1,234** ❌ | 1234 |
+| `12.34` | **1234** ❌ | 12,34 ✅ | 12,34 |
+
+Option B is right for two of the four shapes and wrong for the other two — a lateral move, with a
+larger failure magnitude (1000× under-report rather than 10× over-report). Worse, the under-report
+is the one the server cannot catch: editing the *previous* of two readings only has to stay below
+the last one, so a 1000×-low value passes validation and inflates computed consumption.
+
+**Option A shipped instead.** `parseSpanishNumber` disambiguates at parse time, once the number is
+complete: a dot followed by exactly three digits (and not in leading position) groups thousands,
+anything else is a decimal point. This is the standard locale heuristic and it is correct for all
+four shapes above, plus `1.234.567` → 1234567, `.5` → 0.5 and `1.2345` → 1.2345. It is still a
+heuristic — `1.234` meaning one-point-two-three-four is unreachable — but a meter reading of 1.234
+litres is not a real case, whereas 1234 is.
+
+`normalizeDecimalInput` remains, reduced to a character filter (digits, dots, at most one comma).
+It no longer rewrites the separator. Its value is that `edit-reading-modal` gains input filtering
+it never had.
 
 ### Decision 2 — Use date-fns for local dates
 
@@ -97,7 +124,11 @@ export function formatForInput(value: number): string
 export function normalizeDecimalInput(value: string): string
 ```
 
-**Why `formatForInput` exists.** `formatToSpanish` groups thousands with dots, and `edit-reading-modal.tsx:74` currently uses it to seed the form field. If a grouped value sat in an input guarded by `normalizeDecimalInput`, the user's next keystroke would re-normalise the whole string and destroy the grouping — silently changing the value by 1000×, which is the very class of bug this work exists to remove. Seeding the input ungrouped keeps the invariant simple: **an input's value contains only digits and at most one comma**, so normalisation is idempotent and cannot corrupt anything.
+**Why `formatForInput` exists.** Two reasons, both about not corrupting the value the edit modal resubmits.
+
+First, precision. `reading` is `Decimal(10, 3)` in the schema, but the previous seed used `maximumFractionDigits: 2`. The edit modal always sends `reading`, even when the user only changed a note or a photo — so a stored `1234.567` was seeded as `"1234,57"` and written back as `1234.57`, losing the third decimal silently. `formatForInput` uses three.
+
+Second, shape. Seeding ungrouped keeps the field free of thousands dots, so the value the user sees is the value the parser reads back with no heuristic involved.
 
 Note on the grouping threshold: Intl's `es-ES` locale sets `minimumGroupingDigits: 2`, so four-digit integers are *not* grouped (`1234` → `"1234,00"`) while five-digit ones are (`12345` → `"12.345,00"`). Meter readings in litres routinely exceed five digits, so the hazard is real rather than theoretical: seeding an input with `"12.345,00"` and normalising one keystroke yields `12.345` instead of `12345`. This is pinned by a test.
 

--- a/docs/superpowers/specs/2026-07-30-data-correctness-design.md
+++ b/docs/superpowers/specs/2026-07-30-data-correctness-design.md
@@ -84,11 +84,11 @@ Keeping the hook as a thin wrapper means `add-reading-modal.tsx` and `edit-readi
  *  Comma is the decimal separator; dots are thousands separators. */
 export function parseSpanishNumber(value: string): number
 
-/** Formats a number for DISPLAY, grouped, always 2 decimals: 1234 -> "1.234,00" */
+/** Formats a number for DISPLAY, grouped, always 2 decimals: 12345 -> "12.345,00" */
 export function formatToSpanish(value: number): string
 
 /** Formats a number to seed a text INPUT: ungrouped, always 2 decimals:
- *  1234 -> "1234,00". Never contains a dot, so normalizeDecimalInput is
+ *  12345 -> "12345,00". Never contains a dot, so normalizeDecimalInput is
  *  idempotent over it. */
 export function formatForInput(value: number): string
 
@@ -97,7 +97,9 @@ export function formatForInput(value: number): string
 export function normalizeDecimalInput(value: string): string
 ```
 
-**Why `formatForInput` exists.** `formatToSpanish` groups thousands with dots, and `edit-reading-modal.tsx:74` currently uses it to seed the form field. If a grouped value like `"1.234,00"` sat in an input guarded by `normalizeDecimalInput`, the user's next keystroke would re-normalise the whole string and destroy the grouping (`"1.234,00"` → `"1,23400"`) — silently changing the value by 1000×, which is the very class of bug this work exists to remove. Seeding the input ungrouped keeps the invariant simple: **an input's value contains only digits and at most one comma**, so normalisation is idempotent and cannot corrupt anything.
+**Why `formatForInput` exists.** `formatToSpanish` groups thousands with dots, and `edit-reading-modal.tsx:74` currently uses it to seed the form field. If a grouped value sat in an input guarded by `normalizeDecimalInput`, the user's next keystroke would re-normalise the whole string and destroy the grouping — silently changing the value by 1000×, which is the very class of bug this work exists to remove. Seeding the input ungrouped keeps the invariant simple: **an input's value contains only digits and at most one comma**, so normalisation is idempotent and cannot corrupt anything.
+
+Note on the grouping threshold: Intl's `es-ES` locale sets `minimumGroupingDigits: 2`, so four-digit integers are *not* grouped (`1234` → `"1234,00"`) while five-digit ones are (`12345` → `"12.345,00"`). Meter readings in litres routinely exceed five digits, so the hazard is real rather than theoretical: seeding an input with `"12.345,00"` and normalising one keystroke yields `12.345` instead of `12345`. This is pinned by a test.
 
 `formatToSpanish` is retained unchanged for read-only display; `edit-reading-modal.tsx:74` switches to `formatForInput`. That is its only call site today, so the change is contained.
 

--- a/docs/superpowers/specs/2026-07-30-data-correctness-design.md
+++ b/docs/superpowers/specs/2026-07-30-data-correctness-design.md
@@ -1,0 +1,192 @@
+# Data-Correctness Fixes — Design
+
+**Date:** 2026-07-30
+**Status:** approved
+**Branch:** `data-correctness`, stacked on `worktree-frontend-fixes` (PR #7)
+
+## Problem
+
+Two pre-existing bugs corrupt data that the application treats as authoritative. Both were found while reviewing PR #7 and deliberately left out of it.
+
+### Bug 1 — Spanish number parsing loses the decimal point (10× corruption)
+
+`apps/webapp/src/hooks/use-spanish-number-parser.ts` strips **every** dot as a thousands separator before parsing:
+
+```ts
+const withoutThousands = cleaned.replace(/\./g, '')
+const normalized = withoutThousands.replace(',', '.')
+```
+
+Verified current behaviour:
+
+| Input | Current result | Intended |
+|---|---|---|
+| `"1.234,56"` | `1234.56` | ✅ correct |
+| `"1234,56"` | `1234.56` | ✅ correct |
+| `"1234.5"` | **`12345`** | ❌ should be `1234.5` |
+| `".5"` | **`5`** | ❌ should be `0.5` |
+| `"1.234"` | `1234` | ambiguous — see decision below |
+
+A field worker typing `1234.5` records `12345` litres. The value flows into `addWaterMeterReading` and becomes the meter's stored reading, so it corrupts consumption calculations and any billing derived from them.
+
+The input in `add-reading-modal.tsx:171` permits exactly one separator (`/^[0-9]*[.,]?[0-9]*$/`), so a typed `.` cannot be a thousands separator there. The input in `edit-reading-modal.tsx` has **no** filter at all — it spreads react-hook-form's `field` directly (at two places, lines ~190 and ~283, because the modal renders its whole form twice), so it currently accepts arbitrary text.
+
+### Bug 2 — `toISOString()` produces the wrong calendar day in local time
+
+`toISOString()` converts to UTC. Spain is UTC+1 (UTC+2 in summer), so between local midnight and 01:00/02:00 the UTC date is still *yesterday*. Consequences:
+
+- `add-reading-modal.tsx:36` — a reading taken at 00:30 defaults to yesterday, **and** the `max` attribute forbids selecting today.
+- `analysis/new/page.tsx:204` — same `max` problem for water-analysis records.
+- `use-analysis-form.ts`, `meter-replacement-form.tsx`, `fee-payment-form.tsx` — default dates land a day early.
+- Six export date-range pages — default ranges shift by a day.
+
+17 sites produce date **values**. A further 4 sites use the same call only to stamp a PDF **filename**, where the off-by-one is harmless.
+
+## Decisions
+
+### Decision 1 — Remove the number ambiguity at the input, not in the parser
+
+In Spanish notation `.` is the thousands separator, so `1.234` legitimately means 1234 — but a user typing `1234.5` means 1234,5. No parser can reliably distinguish intent after the fact.
+
+Three approaches were considered:
+
+- **A — parser heuristic:** if a comma is present it wins; otherwise a lone dot followed by exactly 3 digits is a thousands separator, else a decimal separator. Rejected: it guesses, and produces surprising neighbours (`1.234` → 1234 but `1.23` → 1.23).
+- **B — normalise at the input (chosen):** typing `.` inserts `,`. The parser then treats comma as the only decimal separator and dots strictly as thousands, with no special cases.
+- **C — one separator always means decimal:** rejected, silently breaks `1.234` = 1234.
+
+**B is chosen.** It resolves the ambiguity where the intent exists — at the keystroke — rather than inferring it later. On a mobile numeric keypad the decimal key is commonly `.`, and converting it to `,` matches the format the app already displays (`formatToSpanish` always emits a comma, e.g. `1234` → `"1234,00"`). The user sees immediately what will be recorded.
+
+### Decision 2 — Use date-fns for local dates
+
+`date-fns` is already the repository's dominant date library (7 import sites vs 2 for dayjs) and `format(date, 'yyyy-MM-dd')` is local-time by definition. No new dependency.
+
+## Architecture
+
+Two new pure modules under `apps/webapp/src/lib/`, each with a colocated `bun:test` file — matching the existing convention (`user-roles.ts` / `user-roles.test.ts`).
+
+```
+apps/webapp/src/lib/
+  spanish-number.ts        parseSpanishNumber, formatToSpanish, normalizeDecimalInput
+  spanish-number.test.ts
+  local-date.ts            toLocalDateString, todayLocalDateString
+  local-date.test.ts
+
+apps/webapp/src/hooks/use-spanish-number-parser.ts
+  → re-exports the pure functions, same hook signature, so consumers are unchanged
+```
+
+Keeping the hook as a thin wrapper means `add-reading-modal.tsx` and `edit-reading-modal.tsx` keep their current `useSpanishNumberParser()` call sites; only the input `onChange` behaviour changes.
+
+### `lib/spanish-number.ts`
+
+```ts
+/** Converts a Spanish-formatted number string to a JS number.
+ *  Comma is the decimal separator; dots are thousands separators. */
+export function parseSpanishNumber(value: string): number
+
+/** Formats a number for DISPLAY, grouped, always 2 decimals: 1234 -> "1.234,00" */
+export function formatToSpanish(value: number): string
+
+/** Formats a number to seed a text INPUT: ungrouped, always 2 decimals:
+ *  1234 -> "1234,00". Never contains a dot, so normalizeDecimalInput is
+ *  idempotent over it. */
+export function formatForInput(value: number): string
+
+/** Normalises a raw input string as the user types: converts "." to ",",
+ *  keeps at most one comma, and strips anything that is not a digit or comma. */
+export function normalizeDecimalInput(value: string): string
+```
+
+**Why `formatForInput` exists.** `formatToSpanish` groups thousands with dots, and `edit-reading-modal.tsx:74` currently uses it to seed the form field. If a grouped value like `"1.234,00"` sat in an input guarded by `normalizeDecimalInput`, the user's next keystroke would re-normalise the whole string and destroy the grouping (`"1.234,00"` → `"1,23400"`) — silently changing the value by 1000×, which is the very class of bug this work exists to remove. Seeding the input ungrouped keeps the invariant simple: **an input's value contains only digits and at most one comma**, so normalisation is idempotent and cannot corrupt anything.
+
+`formatToSpanish` is retained unchanged for read-only display; `edit-reading-modal.tsx:74` switches to `formatForInput`. That is its only call site today, so the change is contained.
+
+`parseSpanishNumber` contract — the parser becomes strict, because `normalizeDecimalInput` guarantees its input shape:
+
+| Input | Result | Note |
+|---|---|---|
+| `""` / whitespace | `0` | unchanged from today |
+| `"1234"` | `1234` | |
+| `"1234,56"` | `1234.56` | |
+| `"1.234,56"` | `1234.56` | dots are thousands |
+| `"1.234.567,89"` | `1234567.89` | |
+| `"0,5"` | `0.5` | |
+| `",5"` | `0.5` | leading comma |
+| `"1.234"` | `1234` | no comma → dots are thousands (Spanish convention) |
+| `"abc"` | `0` | unchanged from today |
+
+Note the `"1.234"` row: with `normalizeDecimalInput` guarding both inputs and `formatForInput` seeding them, a dot can no longer reach the parser from a form. `parseSpanishNumber` still handles grouped strings so it stays correct for any non-input caller and for values produced by `formatToSpanish`.
+
+`normalizeDecimalInput` contract — the guarantee is that its output contains **only digits and at most one comma**, and that applying it twice changes nothing:
+
+| Input | Result | Note |
+|---|---|---|
+| `"1234.5"` | `"1234,5"` | the fix: dot becomes the decimal comma |
+| `"1234,5"` | `"1234,5"` | already normal |
+| `"1,2,3"` | `"1,23"` | only the first comma survives |
+| `"12.34.5"` | `"12,345"` | first separator wins, the rest are dropped |
+| `"abc12"` | `"12"` | non-numeric stripped |
+| `",5"` | `",5"` | leading comma kept; parser reads it as 0.5 |
+| `""` | `""` | |
+| `"1234,00"` | `"1234,00"` | **idempotent** — this is what `formatForInput` seeds |
+
+### `lib/local-date.ts`
+
+```ts
+/** Formats a Date as YYYY-MM-DD in the runtime's local timezone.
+ *  Replaces `toISOString().split('T')[0]`, which returns the UTC day. */
+export function toLocalDateString(date: Date): string
+
+/** Today as YYYY-MM-DD in local time. */
+export function todayLocalDateString(): string
+```
+
+Both wrap `date-fns`' `format(date, 'yyyy-MM-dd')`.
+
+## Call sites to change
+
+**17 date-value sites** — replace `toISOString().split('T')[0]` / `.slice(0, 10)`:
+
+| File | Lines |
+|---|---|
+| `hooks/use-analysis-form.ts` | 24, 93 |
+| `app/(main)/fees/_components/fee-payment-form.tsx` | 154 |
+| `app/(main)/management/meter-replacement/_components/meter-replacement-form.tsx` | 120, 134 |
+| `app/(main)/analysis/new/page.tsx` | 204 (`max=`) |
+| `app/(main)/water-meter/new/_components/add-reading-modal.tsx` | 36 |
+| `app/(main)/export/readings/page.tsx` | 71, 72 |
+| `app/(main)/export/readings/results/page.tsx` | 57, 58 |
+| `app/(main)/export/incidents/page.tsx` | 31, 32 |
+| `app/(main)/export/incidents/results/page.tsx` | 53, 54 |
+| `app/(main)/export/analysis/dates/page.tsx` | 29, 30 |
+
+**4 filename sites — deliberately unchanged** (an off-by-one in a PDF filename is harmless):
+`export/_hooks/use-readings-pdf-generator.ts` (61, 62), `use-analysis-pdf-generator.ts` (66), `use-incidents-pdf-generator.ts` (61).
+
+**Reading inputs** — apply `normalizeDecimalInput`:
+- `add-reading-modal.tsx` — in `handleReadingChange`, replacing the existing regex gate.
+- `edit-reading-modal.tsx` — both input instances (~190 and ~283, the modal renders its form twice); currently unfiltered.
+- `edit-reading-modal.tsx:74` — seed the form with `formatForInput` instead of `formatToSpanish`, so the field starts ungrouped and normalisation stays idempotent.
+
+## Testing
+
+`bun:test` only, on the pure modules. No jsdom, no React Testing Library — this repo has neither and this work does not add them. `bun test` already runs in CI.
+
+- `spanish-number.test.ts` — every row of both contract tables above, plus:
+  - `normalizeDecimalInput` is **idempotent**: `n(n(x)) === n(x)` for every case in its table.
+  - Round-trip: `parseSpanishNumber(formatForInput(v)) === v` for representative values, which is the property that actually protects the stored reading.
+  - Round-trip through the display format too: `parseSpanishNumber(formatToSpanish(v)) === v`, covering the grouped path.
+- `local-date.test.ts` — the timezone-sensitive case is the point of the change, so test it explicitly by constructing a local `Date` just after midnight and asserting the returned day matches the *local* calendar day, not the UTC one. Use a fixed local date (e.g. `new Date(2026, 6, 30, 0, 30)`) rather than `Date.now()`, so the test is deterministic.
+
+## Risks and behaviour changes
+
+- **Dates shift by up to one day** for anyone using the app between local midnight and 01:00/02:00. That is the fix, but it changes default export ranges and default form dates. Worth stating in the PR.
+- **Typing `.` now produces `,`.** Visible change in the two reading inputs. Intended, and consistent with the displayed format.
+- **`edit-reading-modal` gains input filtering it never had.** Previously arbitrary text was accepted and silently parsed to `0`; now non-numeric characters are rejected as typed. This is a behaviour change, but strictly an improvement.
+- **No historical data is migrated.** Readings already stored wrong stay wrong. Detecting them reliably is not possible from the value alone, so it is out of scope; flag it to the maintainers separately.
+
+## Out of scope
+
+- The failing production build (`components/data-table/data-table-view-options.tsx` imports an undeclared `@radix-ui/react-dropdown-menu`). Touching `package.json`/`bun.lock` is a separate concern.
+- Deferred UI items from the PR #7 review: `Date.now()` in React keys, ~200 hardcoded colour classes, the duplicated mobile/desktop branches in the reading modals, nested `<main>`, doubled container padding.
+- Backfilling or correcting already-stored readings.


### PR DESCRIPTION
Fixes two pre-existing data-correctness bugs found while reviewing #7 and deliberately left out of it. Both silently corrupt values the app treats as authoritative.

**Stacked on #7** — base is `worktree-frontend-fixes`, so this diff shows only the new work. Retarget to `main` once #7 merges.

## Bug 1 — the decimal separator

`parseSpanishNumber` stripped **every** dot as a thousands separator, so a worker typing `1234.5` recorded **12345** litres. The value flows straight into `addWaterMeterReading` and drives consumption and billing.

The fix disambiguates at **parse time**, once the number is complete: a dot followed by exactly three digits groups thousands, anything else is a decimal point.

| typed | before | after |
|---|---|---|
| `1234.5` | **12345** ❌ | 1234,5 ✅ |
| `12.34` | **1234** ❌ | 12,34 ✅ |
| `12.345` | 12345 ✅ | 12345 ✅ |
| `1.234` | 1234 ✅ | 1234 ✅ |
| `1.234,56` | 1234,56 ✅ | 1234,56 ✅ |

### A design reversal worth reading

The approved design normalised the separator *as the user typed* (converting `.` to `,`). Implementation review showed that was worse than the bug: normalising mid-keystroke commits to an interpretation before the number is finished, so `12.345` — the ordinary Spanish grouped form — became `12,345`. It was right for two of the four shapes people type and wrong for the other two, and the new failure was a **1000× under-report** rather than a 10× over-report.

That direction is also the one the server cannot catch. Editing the *previous* of two readings only has to stay below the last one, so a 1000×-low value passes both client and server validation and inflates computed consumption. The approach was reversed; the spec records both options and the evidence.

## Bug 2 — UTC vs the local calendar day

`toISOString().split('T')[0]` returns the **UTC** day. Spain is UTC+1/+2, so between local midnight and 01:00/02:00 it is still yesterday. A reading taken at 00:30 defaulted to yesterday — and where the value fed an input's `max`, today could not even be selected.

17 date-value sites now use `toLocalDateString` / `todayLocalDateString`, built on `date-fns` (already the repo's dominant date library — no new dependency). The 4 PDF-filename sites keep `toISOString()`; an off-by-one in a filename is harmless.

## Also fixed, found during review

`formatForInput` seeded the edit modal at two decimals, but `reading` is `Decimal(10, 3)` and the modal **always** resubmits the reading — even when the user only changed a note or a photo. A stored `1234.567` was written back as `1234.57`. Now three decimals.

## Tests

Both bugs are pure logic, so both are covered by `bun:test` on extracted modules — no jsdom or React Testing Library added. **341 pass / 0 fail**, Biome clean across 556 files.

`local-date.test.ts` pins `process.env.TZ = 'Europe/Madrid'`, so it is a genuine regression test rather than a contractual one: it asserts that `toISOString()` returns the 29th while `toLocalDateString` returns the 30th for a local 30 July 00:30, and it behaves identically on a UTC CI box.

## Behaviour changes to expect

1. **Default dates shift by up to a day** for anyone using the app between local midnight and 01:00/02:00 — export ranges and form defaults included. That is the fix, but it is visible.
2. **The edit modal gains input filtering it never had** — it previously accepted arbitrary text and parsed it to `0`.
3. Reading inputs now reject non-numeric characters as typed rather than accepting them.

## Not done

**Historical data is not migrated.** Readings already stored wrong stay wrong, and they cannot be reliably identified from the value alone. Worth a separate decision.

Also out of scope: the failing production build (an admin file imports an undeclared `@radix-ui/react-dropdown-menu`), and the deferred UI items from #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
