### PR TITLE
fix(webapp): quitar el menú duplicado entre header y sidebar, y dar sesión a la sidebar

### DIFF
--- a/apps/webapp/src/components/layout/header.tsx
+++ b/apps/webapp/src/components/layout/header.tsx
@@ -3,12 +3,18 @@ import type { Session } from 'next-auth'
 import { AccountMenu } from '@/app/(main)/app/_components/account-menu'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { APP_CONFIG } from '@/config/app-config'
+import { hasDedicatedNav } from '@/navigation/main-nav-items'
 
 interface HeaderProps {
   session: Session
 }
 
 export function Header({ session }: HeaderProps) {
+  // Only render the account menu when nothing else covers navigation. Otherwise it
+  // duplicates the sidebar on desktop and the bottom bar's "Más" on mobile — the
+  // latter renders the very same AccountMenuItems.
+  const isOnlyNav = !hasDedicatedNav(session.user.roles ?? [])
+
   return (
     <header className="flex h-14 shrink-0 items-center gap-2 bg-gradient-to-r from-blue-500 via-blue-400 to-blue-300 shadow-lg transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-14">
       <div className="flex w-full items-center justify-between px-3 lg:px-6">
@@ -43,11 +49,13 @@ export function Header({ session }: HeaderProps) {
             </>
           )}
         </div>
-        <div className="flex items-center gap-3">
-          <div className="bg-white/10 backdrop-blur-sm rounded-lg border border-white/10">
-            <AccountMenu />
+        {isOnlyNav && (
+          <div className="flex items-center gap-3">
+            <div className="bg-white/10 backdrop-blur-sm rounded-lg border border-white/10">
+              <AccountMenu />
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </header>
   )

--- a/apps/webapp/src/components/layout/main-sidebar.tsx
+++ b/apps/webapp/src/components/layout/main-sidebar.tsx
@@ -1,10 +1,14 @@
 'use client'
 
+import { LogOut } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { signOut } from 'next-auth/react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarHeader,
@@ -13,6 +17,7 @@ import {
   SidebarMenuItem
 } from '@/components/ui/sidebar'
 import { APP_CONFIG } from '@/config/app-config'
+import { getInitials } from '@/lib/utils'
 import { getActiveNavUrl, getMainNavItems } from '@/navigation/main-nav-items'
 import { useUserStore } from '@/stores/user/user-provider'
 
@@ -52,6 +57,31 @@ export function MainSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+
+      {/* The sidebar is the only nav on desktop, so it has to carry the session:
+          the header no longer duplicates these destinations or the sign-out. */}
+      <SidebarFooter>
+        <div className="flex items-center gap-2 px-2 py-1.5 group-data-[collapsible=icon]:hidden">
+          <Avatar className="size-8 rounded-lg">
+            <AvatarImage src="/favicon/32x32.png" alt="" />
+            <AvatarFallback className="rounded-lg">{getInitials(user.email || '')}</AvatarFallback>
+          </Avatar>
+          <div className="grid flex-1 text-left text-sm leading-tight">
+            <span className="truncate font-semibold">{user.name}</span>
+            <span className="truncate text-xs capitalize text-muted-foreground">
+              {user.roles[0]}
+            </span>
+          </div>
+        </div>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={() => signOut()} tooltip="Cerrar sesión">
+              <LogOut />
+              <span>Cerrar sesión</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
     </Sidebar>
   )
 }

--- a/apps/webapp/src/navigation/main-nav-items.test.ts
+++ b/apps/webapp/src/navigation/main-nav-items.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test'
 import { WATER_METER_READER_ALLOWED_PATHS } from '@/lib/water-meter-reader-paths'
-import { getActiveNavUrl, getMainNavItems, isNavItemActive } from './main-nav-items'
+import {
+  getActiveNavUrl,
+  getMainNavItems,
+  hasDedicatedNav,
+  isNavItemActive
+} from './main-nav-items'
 
 describe('getMainNavItems', () => {
   it('gives staff the full set of destinations', () => {
@@ -99,5 +104,33 @@ describe('getActiveNavUrl', () => {
 
   it('returns null when nothing matches', () => {
     expect(getActiveNavUrl(items, '/privacy')).toBeNull()
+  })
+})
+
+describe('hasDedicatedNav', () => {
+  it('is true for staff, who get both the sidebar and the bottom bar', () => {
+    for (const role of ['ADMIN', 'COMMUNITY_ADMIN', 'MANAGER']) {
+      expect(hasDedicatedNav([role])).toBe(true)
+    }
+  })
+
+  it('is false for reader-only users, whose single destination renders neither', () => {
+    expect(hasDedicatedNav(['WATER_METER_READER'])).toBe(false)
+  })
+
+  it('is false when the user has no role at all', () => {
+    expect(hasDedicatedNav([])).toBe(false)
+  })
+
+  it('mirrors the thresholds MainSidebar and BottomNav gate on', () => {
+    // If either component's own `< 2` check ever changes, this is the pair that has
+    // to change with it, or the header menu stops being the right fallback.
+    const staff = getMainNavItems(['MANAGER'])
+    expect(staff.length).toBeGreaterThanOrEqual(2)
+    expect(staff.filter((item) => item.primary).length).toBeGreaterThanOrEqual(2)
+
+    const reader = getMainNavItems(['WATER_METER_READER'])
+    expect(reader.length).toBeLessThan(2)
+    expect(reader.filter((item) => item.primary).length).toBeLessThan(2)
   })
 })

--- a/apps/webapp/src/navigation/main-nav-items.ts
+++ b/apps/webapp/src/navigation/main-nav-items.ts
@@ -51,6 +51,19 @@ export function getMainNavItems(roles: string[]): MainNavItem[] {
   return []
 }
 
+/**
+ * True when navigation is already covered on both form factors on its own: the
+ * sidebar on desktop (it bails out below two items) and the bottom bar on mobile
+ * (it bails out below two `primary` items). The header's account menu is the
+ * fallback for everyone else — reader-only users and users with no role at all,
+ * for whom it is the only way to navigate or sign out.
+ */
+export function hasDedicatedNav(roles: string[]): boolean {
+  const items = getMainNavItems(roles)
+
+  return items.length >= 2 && items.filter((item) => item.primary).length >= 2
+}
+
 export function isNavItemActive(url: string, pathname: string): boolean {
   if (url === '/') {
     return pathname === '/'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check:write": "biome check --write --max-diagnostics=20000 .",
     "check:errors": "bunx biome check --max-diagnostics=20000 --diagnostic-level=error .",
     "typecheck": "tsc --noEmit -p tsconfig.packages.json",
-    "test:unit": "bun test packages apps/webapp/src/lib",
+    "test:unit": "bun test packages apps/webapp/src/lib apps/webapp/src/navigation",
     "test:integration": "PDA_INTEGRATION=1 bun --env-file=.env.test test apps/webapp/src/server --concurrency 1",
     "test:all": "bun run test:unit && bun run test:integration"
   },


### PR DESCRIPTION
> **Apilada sobre #11** — la base es `worktree-pda-mondariz-mejoras`, no `main`. No tiene relación con las mejoras de Mondariz; va apilada solo para poder verificar el build (en `main` está roto por el import de `@radix-ui/react-dropdown-menu`, que arregla #11).

El staff veía el mismo menú dos veces, en las dos resoluciones.

## Qué pasaba

| | Sidebar izquierda | Menú del header (☰) | Barra inferior |
|---|---|---|---|
| **Desktop (staff)** | 10 entradas | **7 entradas repetidas** + Cerrar sesión | oculta (`md:hidden`) |
| **Móvil (staff)** | inalcanzable (su trigger es `hidden md:flex`) | **7 entradas + Cerrar sesión** | 3 entradas + "Más" → **las mismas 7 + Cerrar sesión** |
| **Lector / sin rol** | oculta (`items.length < 2`) | única navegación | oculta (`primary < 2`) |

`AccountMenu` filtra las 3 entradas `primary` porque se escribió para complementar la barra inferior del móvil, pero se renderizaba en las dos resoluciones. En desktop repetía 7 de las 10 entradas de la sidebar; en móvil era **el mismo componente** (`AccountMenuItems`) pintado dos veces, una en el header y otra dentro del "Más".

Y no se podía borrar el menú del header sin más, porque **la sidebar no tenía "Cerrar sesión"**: era la única salida.

## Qué hace esta PR

- **`MainSidebar` gana un pie de sesión**: usuario conectado (avatar, nombre, rol) y **"Cerrar sesión"**. Respeta el modo colapsado a iconos — el bloque de usuario se oculta y el botón conserva su tooltip. Con esto la sidebar se sostiene sola en desktop.
- **El header solo pinta el menú de cuenta cuando nada más cubre la navegación**, con un helper nuevo `hasDedicatedNav(roles)`. Es decir: lectores y usuarios sin rol, para quienes ese menú es la única forma de navegar y de salir. El helper existe porque `MainSidebar` y `BottomNav` deciden con umbrales propios (`items.length < 2` y `primary < 2`) y esa correspondencia no estaba escrita en ningún sitio; ahora está documentada y con test.

Resultado, sin duplicación en ningún caso:

- **Staff desktop** → solo sidebar (con cerrar sesión). El header queda con logo, comunidad y el botón de plegar.
- **Staff móvil** → solo barra inferior (con "Más" → cerrar sesión).
- **Lector / sin rol** → solo el menú del header, igual que antes.

## De paso: 17 tests que nunca se ejecutaban

`apps/webapp/src/navigation/main-nav-items.test.ts` existía con 17 casos que pasan, pero el glob de `test:unit` era `bun test packages apps/webapp/src/lib`: nunca los corría. Añadido `apps/webapp/src/navigation` al glob. Por eso la cuenta de tests sube de 315 a 336 (17 que ya existían + 4 nuevos de `hasDedicatedNav`).

## Verificación

- `bun run test:unit` → **336 pass, 0 fail**.
- `bun run check:errors` y `bun run typecheck` → limpios.
- `next build` → compila.
- Errores de tipo de `apps/webapp` (fuera del gate de CI): 123 → 122.

## Verificación manual pendiente

No he podido hacer clic (no hay `.env.local` en el entorno). Queda por comprobar con `admin@anceu.com` en desktop que el header ya no tiene ☰ y que la sidebar cierra sesión, tanto desplegada como colapsada a iconos; y con `reader@anceu.com` que el ☰ del header sigue estando, porque es su única salida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
